### PR TITLE
Add node 14 option to engine

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -17,10 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - name: Install latest Yarn
-        run: npm install -g yarn
-      - name: Print Yarn version
-        run: yarn --version
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v1
         with:

--- a/deploy.sh
+++ b/deploy.sh
@@ -92,7 +92,7 @@ selectNodeVersion
 if [ -e "$DEPLOYMENT_TARGET/package.json" ]; then
   cd "$DEPLOYMENT_TARGET"
   echo "Running yarn install"
-  yarn install --ignore-engines
+  yarn install
   exitWithMessageOnError "yarn failed"
   cd - > /dev/null
 fi

--- a/deploy.sh
+++ b/deploy.sh
@@ -92,7 +92,7 @@ selectNodeVersion
 if [ -e "$DEPLOYMENT_TARGET/package.json" ]; then
   cd "$DEPLOYMENT_TARGET"
   echo "Running yarn install"
-  yarn install
+  yarn install --ignore-engines
   exitWithMessageOnError "yarn failed"
   cd - > /dev/null
 fi

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Partio-ohjelmasovelluksen backend",
   "main": "index.js",
   "engines": {
-    "node": "18.x"
+    "node": "18.x || 14.x"
   },
   "scripts": {
     "start": "node dist/index.js",


### PR DESCRIPTION
After updating the staging environment to Node.js version 18, Azure deployment failed due to an incorrect Node.js version complain. This appears to be a known issue with Azure Kudu deployment service but workaround solution is to add also node 14 version to the engine